### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/tests/Unit/DataTable/Filter/AddSegmentMetadataTest.php
+++ b/tests/Unit/DataTable/Filter/AddSegmentMetadataTest.php
@@ -10,6 +10,7 @@ namespace Piwik\Plugins\CustomDimensions\tests\Unit\DataTable\Filter;
 use Piwik\DataTable;
 use Piwik\DataTable\Row;
 use Piwik\Plugins\CustomDimensions\Archiver;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group CustomDimensions
@@ -17,7 +18,7 @@ use Piwik\Plugins\CustomDimensions\Archiver;
  * @group AddSegmentMetadata
  * @group Plugins
  */
-class AddSegmentMetadataTest extends \PHPUnit_Framework_TestCase
+class AddSegmentMetadataTest extends TestCase
 {
     private $filter = 'Piwik\Plugins\CustomDimensions\DataTable\Filter\AddSegmentMetadata';
 

--- a/tests/Unit/Dimension/ActiveTest.php
+++ b/tests/Unit/Dimension/ActiveTest.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Plugins\CustomDimensions\tests\Unit\Dimension;
 use Piwik\Plugins\CustomDimensions\Dimension\Active;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group CustomDimensions
@@ -15,7 +16,7 @@ use Piwik\Plugins\CustomDimensions\Dimension\Active;
  * @group Active
  * @group Plugins
  */
-class ActiveTest extends \PHPUnit_Framework_TestCase
+class ActiveTest extends TestCase
 {
 
     /**

--- a/tests/Unit/Dimension/CaseSensitiveTest.php
+++ b/tests/Unit/Dimension/CaseSensitiveTest.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Plugins\CustomDimensions\tests\Unit\Dimension;
 use Piwik\Plugins\CustomDimensions\Dimension\CaseSensitive;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group CustomDimensions
@@ -15,7 +16,7 @@ use Piwik\Plugins\CustomDimensions\Dimension\CaseSensitive;
  * @group CaseSensitive
  * @group Plugins
  */
-class CaseSensitiveTest extends \PHPUnit_Framework_TestCase
+class CaseSensitiveTest extends TestCase
 {
 
     /**

--- a/tests/Unit/Dimension/ExtractionsTest.php
+++ b/tests/Unit/Dimension/ExtractionsTest.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Plugins\CustomDimensions\tests\Unit\Dimension;
 use Piwik\Plugins\CustomDimensions\Dimension\Extractions;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group CustomDimensions
@@ -15,7 +16,7 @@ use Piwik\Plugins\CustomDimensions\Dimension\Extractions;
  * @group Extractions
  * @group Plugins
  */
-class ExtractionsTest extends \PHPUnit_Framework_TestCase
+class ExtractionsTest extends TestCase
 {
 
     /**

--- a/tests/Unit/Dimension/NameTest.php
+++ b/tests/Unit/Dimension/NameTest.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\CustomDimensions\tests\Unit\Dimension;
 use Piwik\Plugins\CustomDimensions\Dimension\Name;
 use Piwik\Translate;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group CustomDimensions
@@ -16,7 +17,7 @@ use Piwik\Translate;
  * @group Name
  * @group Plugins
  */
-class NameTest extends \PHPUnit_Framework_TestCase
+class NameTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/Unit/Dimension/ScopeTest.php
+++ b/tests/Unit/Dimension/ScopeTest.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Plugins\CustomDimensions\tests\Unit\Dimension;
 use Piwik\Plugins\CustomDimensions\Dimension\Scope;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group CustomDimensions
@@ -15,7 +16,7 @@ use Piwik\Plugins\CustomDimensions\Dimension\Scope;
  * @group Scope
  * @group Plugins
  */
-class ScopeTest extends \PHPUnit_Framework_TestCase
+class ScopeTest extends TestCase
 {
 
     /**


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

refs piwik/piwik#12269