### PR TITLE
Don't queue segment filters but apply them directly

### DIFF
--- a/API.php
+++ b/API.php
@@ -66,12 +66,12 @@ class API extends \Piwik\Plugin\API
             foreach ($parentTable->getRows() as $row) {
                 if ($row->getIdSubDataTable() == $idSubtable) {
                     $parentValue = $row->getColumn('label');
-                    $dataTable->queueFilter('Piwik\Plugins\CustomDimensions\DataTable\Filter\AddSubtableSegmentMetadata', array($idDimension, $parentValue));
+                    $dataTable->filter('Piwik\Plugins\CustomDimensions\DataTable\Filter\AddSubtableSegmentMetadata', array($idDimension, $parentValue));
                     break;
                 }
             }
         } else {
-            $dataTable->queueFilter('Piwik\Plugins\CustomDimensions\DataTable\Filter\AddSegmentMetadata', array($idDimension));
+            $dataTable->filter('Piwik\Plugins\CustomDimensions\DataTable\Filter\AddSegmentMetadata', array($idDimension));
         }
 
         $dataTable->filter('Piwik\Plugins\CustomDimensions\DataTable\Filter\RemoveUserIfNeeded', array($idSite, $period, $date));


### PR DESCRIPTION
They need to be applied directly so the generated segment metadata references the correct label. Otherwise, if you later rename the label (eg in a plugin that allows to rename/translate labels into different languages), it would use the translated name in the segment string and the segment wouldn't work

needed for https://github.com/matomo-org/matomo/pull/13766 