### PR TITLE
Fix permission check for get configured dimensions

### DIFF
--- a/API.php
+++ b/API.php
@@ -191,7 +191,7 @@ class API extends \Piwik\Plugin\API
      */
     public function getConfiguredCustomDimensions($idSite)
     {
-        Piwik::checkUserHasWriteAccess($idSite);
+        Piwik::checkUserHasViewAccess($idSite);
 
         $configs = $this->getConfiguration()->getCustomDimensionsForSite($idSite);
 


### PR DESCRIPTION
A view user can VIEW dimensions, and other entities but not write. So the write permission check was wrong and only view permission is needed.