### PR TITLE
Require only view permissions to view scopes

### DIFF
--- a/API.php
+++ b/API.php
@@ -228,7 +228,7 @@ class API extends \Piwik\Plugin\API
      */
     public function getAvailableScopes($idSite)
     {
-        Piwik::checkUserHasWriteAccess($idSite);
+        Piwik::checkUserHasViewAccess($idSite);
 
         $scopes = array();
         foreach (CustomDimensions::getPublicScopes() as $scope) {

--- a/tests/Integration/ApiTest.php
+++ b/tests/Integration/ApiTest.php
@@ -184,21 +184,21 @@ class ApiTest extends IntegrationTestCase
 
     /**
      * @expectedException \Exception
-     * @expectedExceptionMessage checkUserHasWriteAccess
+     * @expectedExceptionMessage checkUserHasViewAccess
      */
     public function test_getConfiguredCustomDimensions_shouldFailWhenNotHavingAdminPermissions()
     {
-        $this->setUser();
+        $this->setAnonymousUser();
         $this->api->getConfiguredCustomDimensions($idSite = 1);
     }
 
     /**
      * @expectedException \Exception
-     * @expectedExceptionMessage checkUserHasWriteAccess
+     * @expectedExceptionMessage checkUserHasViewAccess
      */
     public function test_getAvailableScopes_shouldFailWhenNotHavingAdminPermissions()
     {
-        $this->setUser();
+        $this->setAnonymousUser();
         $this->api->getAvailableScopes($idSite = 1);
     }
 


### PR DESCRIPTION
View permission is the correct permission plus it might fix issues like https://github.com/matomo-org/matomo/issues/13781