### PR TITLE
Fix custom dimension repeated when generating reports

### DIFF
--- a/GetCustomDimension.php
+++ b/GetCustomDimension.php
@@ -172,7 +172,7 @@ class GetCustomDimension extends Report
         $idSite = $this->getIdSiteFromInfos($infos);
 
         if (isset($idSite)) {
-            $this->addReportMetadataForEachDimension($availableReports, $idSite);
+            $availableReports[] = $this->buildReportMetadata();
         }
     }
 
@@ -191,17 +191,6 @@ class GetCustomDimension extends Report
         }
 
         return $this->dimensionCache[$idSite];
-    }
-
-    protected function addReportMetadataForEachDimension(&$availableReports, $idSite)
-    {
-        $dimensions = $this->getActiveDimensionsForSite($idSite);
-
-        foreach ($dimensions as $dimension) {
-            if ($this->initThisReportFromDimension($dimension)) {
-                $availableReports[] = $this->buildReportMetadata();
-            }
-        }
     }
 
     public function initThisReportFromDimension($dimension)


### PR DESCRIPTION
fix #112

they would be likely also repeated in mobile app etc. It is quite likely a regression from https://github.com/matomo-org/plugin-CustomDimensions/pull/100/files where we now add a report for each dimension, but before there was only one report for all dimensions.