### PR TITLE
Truncate custom dimension value to avoid data too long errors

### DIFF
--- a/Tracker/CustomDimensionsRequestProcessor.php
+++ b/Tracker/CustomDimensionsRequestProcessor.php
@@ -99,7 +99,7 @@ class CustomDimensionsRequestProcessor extends RequestProcessor
             $value = Common::getRequestVar($field, '', 'string', $params);
             $hasSentEmptyString = isset($params[$field]) && $params[$field] === '';
             if ($value !== '' || $hasSentEmptyString) {
-                $values[$dbField] = $value;
+                $values[$dbField] = Common::mb_substr($value, 0, 255);
                 continue;
             }
 
@@ -120,7 +120,7 @@ class CustomDimensionsRequestProcessor extends RequestProcessor
                         continue;
                     }
 
-                    $values[$dbField] = $value;
+                    $values[$dbField] = Common::mb_substr($value, 0, 255);
                     break;
                 }
             }


### PR DESCRIPTION
Avoid eg this error

> Error in Matomo (tracker): Error query: SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'custom_dimension_1' at row 1 In query: INSERT INTO log_link_visit_action (idvisit, idsite, idvisitor, idaction_url, idaction_url_ref, idaction_name_ref, server_time, idpageview, interaction_position, time_spent_ref_action, idaction_name, custom_float, custom_dimension_1) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?) Parameters: array (   ...